### PR TITLE
fix macos unable to add route with H/G flag

### DIFF
--- a/src/unix_bsd/mod.rs
+++ b/src/unix_bsd/mod.rs
@@ -197,7 +197,17 @@ fn delete_route(route: &Route) -> io::Result<()> {
 }
 
 fn add_or_del_route_req(route: &Route, rtm_type: u8) -> io::Result<m_rtmsg> {
-    let rtm_flags = RTF_STATIC | RTF_UP;
+    let mut rtm_flags = RTF_STATIC | RTF_UP;
+
+    if route.gateway.is_some() {
+        rtm_flags |= RTF_GATEWAY;
+    }
+
+    if (route.destination.is_ipv4() && route.prefix == 32)
+        || (route.destination.is_ipv6() && route.prefix == 128)
+    {
+        rtm_flags |= RTF_HOST;
+    }
 
     let mut rtm_addrs = RTA_DST | RTA_NETMASK;
     if rtm_type == RTM_ADD as u8 || route.gateway.is_some() {


### PR DESCRIPTION
# Fix route flags for host-specific gateway routes on BSD systems

  ## Problem
  When adding host-specific routes (IPv4 /32 or IPv6 /128) with gateways on macOS/BSD systems, the route manager was incorrectly setting route flags, resulting in "USc" flags instead of the expected "UGHS" flags in `netstat -rn -f inet` output.

  **Before:**
```
  Destination            Gateway          Flag                  Netif
  198.198.198.198       10.4.20.1          USc                   en0
```

  **After:**
```
  Destination            Gateway          Flag                   Netif
  198.198.198.198       10.4.20.1          UGHS                 en0
```

  ## Root Cause
  The original code hardcoded `RTF_STATIC | RTF_UP` for all routes, which prevented adding gateway and host routes.
   This didn't properly reflect BSD routing semantics where:
  - `RTF_STATIC` = manually added route (vs dynamically learned)
  - `RTF_HOST` = single host route (/32 IPv4 or /128 IPv6)
  - `RTF_GATEWAY` = route uses specified gateway

  These flags should be supported.

  ## Solution
  - Set `RTF_STATIC` for all manually added routes (preserves existing
  behavior)
  - Add `RTF_GATEWAY` when a gateway address is provided
  - Add `RTF_HOST` for host-specific routes (/32 IPv4, /128 IPv6)

  ## Changes
  - Modified `add_or_del_route_req()` in `src/unix_bsd/mod.rs` to
  dynamically set route flags based on route characteristics
  - Host routes with gateways now correctly show "UGHS" flags (Up, Gateway,
  Host)
  - Network routes with gateways continue to show "UGS" flags (Up, Gateway,
   Static)

  ## Testing
  - [x] Verified host route `198.198.198.198/32` via `10.4.20.1` shows UGHS
  flags
  - [x] Route addition and deletion functions properly

  This fix ensures route_manager follows standard BSD routing flag semantics and produces correct `netstat` output.